### PR TITLE
Add reusable tool starter template

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 This repository hosts a collection of Microsoft 365 helper utilities that share a unified look and feel. Use the guidelines below when extending the workspace with new tools so that every experience feels cohesive.
 
+## Available Tools & Templates
+- **Organization License Viewer** (`/org-license-viewer`): Visualize reporting lines, highlight ChatGPT license coverage, and explore organizational metrics with collapsible filter panels and chart controls.
+- **Profile Data Appender** (`/user-data-appender`): Upload CSV/Excel files, append Microsoft 365 profile attributes, and export enriched lists with built-in progress and status messaging.
+- **Tool Starter Template** (`/tool-template`): A base layout with Microsoft Graph token handling, collapsible input and settings panels, and a neutral main canvas ready for custom tables, charts, or outputs.
+
 ## Landing Page Layout
 - Cards should be wide rectangles that highlight the tool name, a short description, and structured “Data” and “Features” callouts.
 - Use the existing `tool-card`, `meta-grid`, and `meta-item` classes from `shared/home.css` to keep the layout consistent.

--- a/index.html
+++ b/index.html
@@ -84,6 +84,28 @@
           <a class="btn btn-primary" href="user-data-appender/index.html">Open Appender</a>
         </section>
 
+        <section class="tool-card">
+          <h2>Tool Starter Template</h2>
+          <p>Kickstart new utilities with prebuilt token, input, and settings panels plus a ready-made visualization area.</p>
+          <div class="meta meta-grid">
+            <div class="meta-item">
+              <div class="meta-heading">
+                <span aria-hidden="true">📂</span>
+                <span>Data</span>
+              </div>
+              <p>Bring your own Microsoft Graph queries</p>
+            </div>
+            <div class="meta-item">
+              <div class="meta-heading">
+                <span aria-hidden="true">🛠️</span>
+                <span>Features</span>
+              </div>
+              <p>Token sharing, collapsible inputs, ready UI shell</p>
+            </div>
+          </div>
+          <a class="btn btn-primary" href="tool-template/index.html">Open Template</a>
+        </section>
+
         <section class="tool-card coming-soon">
           <h2>More tools coming soon</h2>
           <p>Stay tuned for additional utilities that build on this shared foundation of styling, layout, and Microsoft Graph access.</p>

--- a/tool-template/index.html
+++ b/tool-template/index.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Tool Starter Template</title>
+  <link rel="stylesheet" href="../shared/styles.css">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <div class="app-container">
+    <header class="header">
+      <h1>Tool Starter Template</h1>
+      <div class="header-actions">
+        <a class="btn btn-secondary" href="../index.html">🏠 Home</a>
+        <button class="btn btn-secondary" onclick="AppUI.toggleDarkMode()">🌙 Dark Mode</button>
+      </div>
+    </header>
+
+    <div class="main-content">
+      <aside class="setup-panel" id="setupPanel">
+        <!-- Graph Token Section -->
+        <div class="collapsible-section">
+          <div class="collapsible-header" onclick="AppUI.toggleSection('tokenSection')">
+            <span class="collapse-icon" id="tokenSectionIcon">▼</span>
+            <h3 style="margin: 0;">Microsoft Graph Token</h3>
+          </div>
+
+          <div class="collapsible-content" id="tokenSection">
+            <div class="wizard-step">
+              <h3>
+                <span class="step-number">1</span>
+                Connect to Microsoft Graph
+              </h3>
+              <p class="helper-text">
+                Paste the access token from <a href="https://developer.microsoft.com/en-us/graph/graph-explorer" target="_blank" rel="noreferrer">Microsoft Graph Explorer</a> to reuse it across tools.
+              </p>
+              <div class="form-group">
+                <label for="graphToken">Access Token:</label>
+                <input type="password" id="graphToken" placeholder="Paste your Microsoft Graph access token here...">
+                <small class="form-hint" id="tokenStatus">No token stored yet.</small>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Input Section -->
+        <div class="collapsible-section">
+          <div class="collapsible-header" onclick="AppUI.toggleSection('inputSection')">
+            <span class="collapse-icon" id="inputSectionIcon">▼</span>
+            <h3 style="margin: 0;">Input</h3>
+          </div>
+
+          <div class="collapsible-content" id="inputSection">
+            <div class="wizard-step">
+              <h3>
+                <span class="step-number">2</span>
+                Provide Source Data
+              </h3>
+              <p class="helper-text">Use any of these starter controls and replace them with fields specific to your tool.</p>
+              <div class="form-group">
+                <label for="inputText">Sample Text Field</label>
+                <input type="text" id="inputText" placeholder="Enter a value">
+              </div>
+              <div class="form-group">
+                <label for="inputSelect">Sample Dropdown</label>
+                <select id="inputSelect">
+                  <option value="">Select an option</option>
+                  <option value="optionA">Option A</option>
+                  <option value="optionB">Option B</option>
+                </select>
+              </div>
+              <div class="form-group">
+                <label for="inputFile">Sample File Upload</label>
+                <div class="file-upload">
+                  <input type="file" id="inputFile">
+                  <label class="file-upload-label" for="inputFile">
+                    📁 Click to upload
+                    <br>
+                    <small>Accepts any file type in this template.</small>
+                  </label>
+                </div>
+              </div>
+              <button class="btn btn-primary" id="inputActionButton">Run Template Action</button>
+              <div class="status-message" id="inputStatus" role="status" aria-live="polite"></div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Settings Section -->
+        <div class="collapsible-section">
+          <div class="collapsible-header" onclick="AppUI.toggleSection('settingsSection')">
+            <span class="collapse-icon" id="settingsSectionIcon">▼</span>
+            <h3 style="margin: 0;">Settings</h3>
+          </div>
+
+          <div class="collapsible-content" id="settingsSection">
+            <div class="wizard-step">
+              <h3>
+                <span class="step-number">3</span>
+                Configure Behavior
+              </h3>
+              <div class="form-group toggle-row">
+                <label class="switch">
+                  <input type="checkbox" id="settingToggle" checked>
+                  <span class="slider"></span>
+                </label>
+                <div>
+                  <div class="form-label">Enable Sample Toggle</div>
+                  <small class="form-hint">Use toggles for boolean flags or feature switches.</small>
+                </div>
+              </div>
+              <div class="form-group">
+                <label for="settingNumber">Sample Numeric Setting</label>
+                <input type="number" id="settingNumber" value="5" min="1" max="10">
+              </div>
+              <div class="form-group">
+                <label for="settingNotes">Notes</label>
+                <textarea id="settingNotes" rows="3" placeholder="Capture reminders about how this tool works."></textarea>
+              </div>
+            </div>
+          </div>
+        </div>
+      </aside>
+
+      <main class="viz-container">
+        <section class="template-state" id="templateState">
+          <h2>Ready to Build</h2>
+          <p>
+            This area is intentionally minimal. Replace it with tables, charts, or any visualization that your tool requires.
+          </p>
+          <ul>
+            <li>The badge below updates when the template action runs.</li>
+            <li>Reuse the helper functions in <code>../shared/ui.js</code> and <code>../shared/graph-token.js</code>.</li>
+          </ul>
+          <div class="result-badge" id="resultBadge">No actions run yet.</div>
+        </section>
+      </main>
+    </div>
+  </div>
+
+  <script src="../shared/ui.js"></script>
+  <script src="../shared/graph-token.js"></script>
+  <script src="template.js"></script>
+</body>
+</html>

--- a/tool-template/styles.css
+++ b/tool-template/styles.css
@@ -1,0 +1,111 @@
+.template-state {
+  max-width: 720px;
+  margin: 2rem auto;
+  padding: 2rem;
+  background: var(--bg);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  line-height: 1.7;
+}
+
+.template-state h2 {
+  font-size: 1.5rem;
+  margin-bottom: 1rem;
+}
+
+.template-state ul {
+  margin: 1rem 0 1.5rem;
+  padding-left: 1.25rem;
+}
+
+.template-state li + li {
+  margin-top: 0.5rem;
+}
+
+.result-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  color: var(--text);
+  font-weight: 500;
+  box-shadow: var(--shadow);
+}
+
+.result-badge.success {
+  background: rgba(0, 168, 84, 0.15);
+  border-color: var(--success);
+  color: var(--success);
+}
+
+.result-badge.muted {
+  opacity: 0.65;
+}
+
+.toggle-row {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 48px;
+  height: 26px;
+}
+
+.switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.slider {
+  position: absolute;
+  cursor: pointer;
+  inset: 0;
+  background: var(--border);
+  border-radius: 999px;
+  transition: var(--transition);
+}
+
+.slider::before {
+  position: absolute;
+  content: "";
+  height: 20px;
+  width: 20px;
+  left: 3px;
+  top: 3px;
+  background: white;
+  border-radius: 50%;
+  transition: var(--transition);
+  box-shadow: var(--shadow);
+}
+
+.switch input:checked + .slider {
+  background: var(--primary);
+}
+
+.switch input:checked + .slider::before {
+  transform: translateX(22px);
+}
+
+.form-label {
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+
+#inputStatus {
+  margin-top: 1rem;
+}
+
+@media (max-width: 960px) {
+  .template-state {
+    margin: 1.5rem;
+    padding: 1.5rem;
+  }
+}

--- a/tool-template/template.js
+++ b/tool-template/template.js
@@ -1,0 +1,119 @@
+const TemplateApp = (() => {
+  function updateTokenStatus(token) {
+    const status = document.getElementById('tokenStatus');
+    if (!status) {
+      return;
+    }
+
+    if (!token) {
+      status.textContent = 'No token stored yet.';
+      return;
+    }
+
+    const preview = `${token.slice(0, 12)}…${token.slice(-6)}`;
+    status.textContent = `Token stored (${token.length} characters, preview: ${preview}).`;
+  }
+
+  function formatSettingsSummary() {
+    const toggle = document.getElementById('settingToggle');
+    const numberField = document.getElementById('settingNumber');
+    const notes = document.getElementById('settingNotes');
+
+    const parts = [];
+    if (toggle) {
+      parts.push(`Toggle ${toggle.checked ? 'enabled' : 'disabled'}`);
+    }
+    if (numberField) {
+      parts.push(`Number set to ${numberField.value || 'n/a'}`);
+    }
+    if (notes && notes.value.trim()) {
+      parts.push(`Notes captured (${notes.value.trim().length} chars)`);
+    }
+
+    return parts.join(' • ') || 'Default settings in use';
+  }
+
+  function runTemplateAction() {
+    const inputField = document.getElementById('inputText');
+    const selectField = document.getElementById('inputSelect');
+    const fileField = document.getElementById('inputFile');
+    const status = document.getElementById('inputStatus');
+    const resultBadge = document.getElementById('resultBadge');
+
+    if (!status || !resultBadge) {
+      return;
+    }
+
+    const details = [];
+    if (inputField && inputField.value.trim()) {
+      details.push(`Text: "${inputField.value.trim()}"`);
+    }
+    if (selectField && selectField.value) {
+      details.push(`Dropdown: ${selectField.options[selectField.selectedIndex].text}`);
+    }
+    if (fileField && fileField.files && fileField.files.length > 0) {
+      details.push(`File: ${fileField.files[0].name}`);
+    }
+
+    const message = details.length > 0
+      ? `Template action triggered with ${details.join(', ')}.`
+      : 'Template action triggered with default values.';
+
+    status.textContent = `${message} ${formatSettingsSummary()}.`;
+    status.className = 'status-message status-success';
+    status.style.display = 'flex';
+
+    resultBadge.textContent = 'Template action completed successfully';
+    resultBadge.classList.remove('muted');
+    resultBadge.classList.add('success');
+  }
+
+  function bindEvents() {
+    const actionButton = document.getElementById('inputActionButton');
+    if (actionButton) {
+      actionButton.addEventListener('click', event => {
+        event.preventDefault();
+        runTemplateAction();
+      });
+    }
+
+    const notesField = document.getElementById('settingNotes');
+    if (notesField) {
+      notesField.addEventListener('input', () => {
+        const resultBadge = document.getElementById('resultBadge');
+        if (!resultBadge) {
+          return;
+        }
+        if (notesField.value.trim()) {
+          resultBadge.classList.remove('muted');
+        } else if (!resultBadge.classList.contains('success')) {
+          resultBadge.classList.add('muted');
+        }
+      });
+    }
+  }
+
+  function collapseDefaults() {
+    AppUI.setSectionCollapsed('tokenSection', true);
+    AppUI.setSectionCollapsed('inputSection', true);
+    AppUI.setSectionCollapsed('settingsSection', false);
+  }
+
+  function initialize() {
+    AppUI.initialize();
+    GraphTokenManager.initialize({ onTokenChange: updateTokenStatus });
+    collapseDefaults();
+    bindEvents();
+
+    const resultBadge = document.getElementById('resultBadge');
+    if (resultBadge) {
+      resultBadge.classList.add('muted');
+    }
+  }
+
+  return { initialize };
+})();
+
+window.addEventListener('DOMContentLoaded', () => {
+  TemplateApp.initialize();
+});


### PR DESCRIPTION
## Summary
- add a Tool Starter Template page that bundles reusable Microsoft Graph token, input, and settings panels with starter UI copy
- provide template-specific styling and interactivity so new tools can reuse the collapsible layout immediately
- surface the template on the landing page and document it alongside existing tools in the workspace README

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_b_68ce83a847308328bd2dcb0b720d0c0e