### PR TITLE
Add column comparison tool for CSV and Excel datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This repository hosts a collection of Microsoft 365 helper utilities that share 
 ## Available Tools & Templates
 - **Organization License Viewer** (`/org-license-viewer`): Visualize reporting lines, highlight ChatGPT license coverage, and explore organizational metrics with collapsible filter panels and chart controls.
 - **Profile Data Appender** (`/user-data-appender`): Upload CSV/Excel files, append Microsoft 365 profile attributes, and export enriched lists with built-in progress and status messaging.
+- **Column Comparison Tool** (`/column-compare`): Compare columns from two CSV/Excel files to highlight shared values, gaps, and duplicates with configurable matching rules.
 - **Tool Starter Template** (`/tool-template`): A base layout with Microsoft Graph token handling, collapsible input and settings panels, and a neutral main canvas ready for custom tables, charts, or outputs.
 
 ## Landing Page Layout

--- a/column-compare/comparer.js
+++ b/column-compare/comparer.js
@@ -1,0 +1,718 @@
+const ColumnComparer = (() => {
+  const state = {
+    datasets: { A: null, B: null },
+    selections: { A: '', B: '' },
+    results: null
+  };
+
+  const elements = {};
+
+  function cacheElements() {
+    elements.datasetInputs = {
+      A: document.getElementById('datasetAFile'),
+      B: document.getElementById('datasetBFile')
+    };
+    elements.datasetSummaries = {
+      A: document.getElementById('datasetASummary'),
+      B: document.getElementById('datasetBSummary')
+    };
+    elements.datasetStatuses = {
+      A: document.getElementById('datasetAStatus'),
+      B: document.getElementById('datasetBStatus')
+    };
+    elements.columnSelects = {
+      A: document.getElementById('columnSelectA'),
+      B: document.getElementById('columnSelectB')
+    };
+    elements.optionToggles = {
+      ignoreCase: document.getElementById('ignoreCaseToggle'),
+      trim: document.getElementById('trimToggle'),
+      skipBlank: document.getElementById('skipBlankToggle')
+    };
+    elements.compareButton = document.getElementById('compareButton');
+    elements.comparisonStatus = document.getElementById('comparisonStatus');
+    elements.introState = document.getElementById('introState');
+    elements.overviewSection = document.getElementById('overviewSection');
+    elements.matchesSection = document.getElementById('matchesSection');
+    elements.onlyASection = document.getElementById('onlyASection');
+    elements.onlyBSection = document.getElementById('onlyBSection');
+    elements.duplicatesSection = document.getElementById('duplicatesSection');
+    elements.overviewDescription = document.getElementById('overviewDescription');
+    elements.selectedColumns = document.getElementById('selectedColumns');
+    elements.summaryGrid = document.getElementById('summaryGrid');
+    elements.matchesTableBody = document.getElementById('matchesTableBody');
+    elements.onlyATableBody = document.getElementById('onlyATableBody');
+    elements.onlyBTableBody = document.getElementById('onlyBTableBody');
+    elements.duplicatesATableBody = document.getElementById('duplicatesATableBody');
+    elements.duplicatesBTableBody = document.getElementById('duplicatesBTableBody');
+    elements.tableEmptyStates = {
+      matches: document.getElementById('matchesEmpty'),
+      onlyA: document.getElementById('onlyAEmpty'),
+      onlyB: document.getElementById('onlyBEmpty'),
+      duplicatesA: document.getElementById('duplicatesAEmpty'),
+      duplicatesB: document.getElementById('duplicatesBEmpty')
+    };
+    elements.tokenStatus = document.getElementById('tokenStatus');
+  }
+
+  function attachEventListeners() {
+    elements.datasetInputs.A?.addEventListener('change', event => {
+      const [file] = event.target.files;
+      loadDataset('A', file);
+    });
+
+    elements.datasetInputs.B?.addEventListener('change', event => {
+      const [file] = event.target.files;
+      loadDataset('B', file);
+    });
+
+    elements.columnSelects.A?.addEventListener('change', event => {
+      state.selections.A = event.target.value;
+      invalidateResults('Column selection changed. Run the comparison again to refresh results.');
+      updateCompareButtonState();
+    });
+
+    elements.columnSelects.B?.addEventListener('change', event => {
+      state.selections.B = event.target.value;
+      invalidateResults('Column selection changed. Run the comparison again to refresh results.');
+      updateCompareButtonState();
+    });
+
+    elements.optionToggles.ignoreCase?.addEventListener('change', () => {
+      invalidateResults('Comparison options changed. Run the comparison again to refresh results.');
+    });
+
+    elements.optionToggles.trim?.addEventListener('change', () => {
+      invalidateResults('Comparison options changed. Run the comparison again to refresh results.');
+    });
+
+    elements.optionToggles.skipBlank?.addEventListener('change', () => {
+      invalidateResults('Comparison options changed. Run the comparison again to refresh results.');
+    });
+
+    elements.compareButton?.addEventListener('click', () => runComparison());
+  }
+
+  function updateTokenStatus(token) {
+    if (!elements.tokenStatus) {
+      return;
+    }
+
+    if (!token) {
+      elements.tokenStatus.textContent = 'No token stored yet.';
+      return;
+    }
+
+    const start = token.slice(0, 12);
+    const end = token.slice(-6);
+    const preview = token.length > 18 ? `${start}…${end}` : token;
+    elements.tokenStatus.textContent = `Token stored (${token.length} characters, preview: ${preview}).`;
+  }
+
+  function invalidateResults(message) {
+    if (state.results) {
+      setStatus(elements.comparisonStatus, message, 'info');
+    }
+
+    state.results = null;
+    elements.overviewSection.hidden = true;
+    elements.matchesSection.hidden = true;
+    elements.onlyASection.hidden = true;
+    elements.onlyBSection.hidden = true;
+    elements.duplicatesSection.hidden = true;
+    if (elements.introState) {
+      elements.introState.style.display = '';
+    }
+  }
+
+  function setStatus(element, message, type = 'info') {
+    if (!element) {
+      return;
+    }
+
+    element.className = 'status-message';
+    element.style.display = 'none';
+
+    if (!message) {
+      element.textContent = '';
+      return;
+    }
+
+    element.textContent = message;
+    element.classList.add(`status-${type}`);
+    element.style.display = 'flex';
+  }
+
+  async function loadDataset(key, file) {
+    const summaryEl = elements.datasetSummaries[key];
+    const statusEl = elements.datasetStatuses[key];
+    const selectEl = elements.columnSelects[key];
+
+    if (!file) {
+      state.datasets[key] = null;
+      state.selections[key] = '';
+      if (summaryEl) {
+        summaryEl.textContent = 'No file selected yet.';
+      }
+      if (selectEl) {
+        resetColumnSelect(selectEl, key);
+      }
+      setStatus(statusEl, 'File selection cleared.', 'info');
+      updateCompareButtonState();
+      invalidateResults();
+      return;
+    }
+
+    setStatus(statusEl, `Loading ${file.name}…`, 'info');
+
+    try {
+      const dataset = await parseFile(file);
+      dataset.fileName = file.name;
+      state.datasets[key] = dataset;
+      state.selections[key] = '';
+      if (summaryEl) {
+        summaryEl.textContent = `${file.name} • ${dataset.rows.length} rows, ${dataset.columns.length} columns`;
+      }
+      if (selectEl) {
+        populateColumnSelect(selectEl, dataset.columns, key);
+      }
+      setStatus(statusEl, `Loaded ${dataset.rows.length} rows and ${dataset.columns.length} columns.`, 'success');
+      invalidateResults('Dataset changed. Run the comparison again to refresh results.');
+      if (state.datasets.A && state.datasets.B) {
+        AppUI.setSectionCollapsed('loadSection', true);
+      }
+    } catch (error) {
+      console.error('Failed to load dataset', error);
+      state.datasets[key] = null;
+      state.selections[key] = '';
+      if (summaryEl) {
+        summaryEl.textContent = 'Unable to read file.';
+      }
+      if (selectEl) {
+        resetColumnSelect(selectEl, key);
+      }
+      setStatus(statusEl, `Unable to load file: ${error.message || 'Unknown error'}`, 'error');
+    } finally {
+      updateCompareButtonState();
+    }
+  }
+
+  function resetColumnSelect(selectEl, key) {
+    selectEl.innerHTML = '';
+    const option = document.createElement('option');
+    option.value = '';
+    option.textContent = key === 'A' ? 'Load Dataset A to choose a column' : 'Load Dataset B to choose a column';
+    selectEl.appendChild(option);
+    selectEl.disabled = true;
+  }
+
+  function populateColumnSelect(selectEl, columns, key) {
+    const previousSelection = state.selections[key];
+
+    selectEl.innerHTML = '';
+    const placeholder = document.createElement('option');
+    placeholder.value = '';
+    placeholder.textContent = columns.length
+      ? `Select a column (${columns.length} available)`
+      : 'No columns detected';
+    selectEl.appendChild(placeholder);
+
+    columns.forEach(columnName => {
+      const option = document.createElement('option');
+      option.value = columnName;
+      option.textContent = columnName;
+      selectEl.appendChild(option);
+    });
+
+    selectEl.disabled = columns.length === 0;
+
+    if (columns.length > 0) {
+      if (previousSelection && columns.includes(previousSelection)) {
+        selectEl.value = previousSelection;
+        state.selections[key] = previousSelection;
+      } else {
+        selectEl.value = columns[0];
+        state.selections[key] = columns[0];
+      }
+      updateCompareButtonState();
+    } else {
+      state.selections[key] = '';
+      updateCompareButtonState();
+    }
+  }
+
+  function updateCompareButtonState() {
+    const ready = Boolean(state.datasets.A && state.datasets.B && state.selections.A && state.selections.B);
+    if (elements.compareButton) {
+      elements.compareButton.disabled = !ready;
+    }
+  }
+
+  function getOptions() {
+    return {
+      ignoreCase: Boolean(elements.optionToggles.ignoreCase?.checked),
+      trim: Boolean(elements.optionToggles.trim?.checked),
+      skipBlank: Boolean(elements.optionToggles.skipBlank?.checked)
+    };
+  }
+
+  function normalizeValue(value, options) {
+    let text = '';
+
+    if (value !== undefined && value !== null) {
+      if (value instanceof Date) {
+        text = value.toISOString();
+      } else {
+        text = String(value);
+      }
+    }
+
+    if (options.trim) {
+      text = text.trim();
+    }
+
+    if (text.length === 0 && options.skipBlank) {
+      return null;
+    }
+
+    const normalized = options.ignoreCase ? text.toLowerCase() : text;
+
+    return {
+      normalized,
+      display: text
+    };
+  }
+
+  function collectColumnValues(dataset, columnName, options) {
+    const map = new Map();
+    let valueCount = 0;
+
+    dataset.rows.forEach((row, index) => {
+      const raw = Object.prototype.hasOwnProperty.call(row, columnName) ? row[columnName] : '';
+      const normalized = normalizeValue(raw, options);
+      if (!normalized) {
+        return;
+      }
+
+      valueCount += 1;
+      if (!map.has(normalized.normalized)) {
+        map.set(normalized.normalized, {
+          key: normalized.normalized,
+          display: normalized.display,
+          count: 1
+        });
+      } else {
+        const entry = map.get(normalized.normalized);
+        entry.count += 1;
+        if (!entry.display && normalized.display) {
+          entry.display = normalized.display;
+        }
+      }
+    });
+
+    return { map, valueCount };
+  }
+
+  function formatValueForDisplay(value) {
+    if (value === null || value === undefined || value === '') {
+      return '(blank)';
+    }
+    return value;
+  }
+
+  function combineDisplay(entryA, entryB) {
+    const displays = new Set();
+    if (entryA?.display) {
+      displays.add(entryA.display);
+    }
+    if (entryB?.display) {
+      displays.add(entryB.display);
+    }
+
+    if (!displays.size) {
+      return '(blank)';
+    }
+
+    return Array.from(displays).join(' | ');
+  }
+
+  function computeComparison(datasetA, datasetB, columnA, columnB, options) {
+    const valuesA = collectColumnValues(datasetA, columnA, options);
+    const valuesB = collectColumnValues(datasetB, columnB, options);
+
+    const matches = [];
+    const onlyInA = [];
+    const onlyInB = [];
+    const duplicatesA = [];
+    const duplicatesB = [];
+
+    valuesA.map.forEach(entryA => {
+      const counterpart = valuesB.map.get(entryA.key);
+      if (counterpart) {
+        matches.push({
+          value: combineDisplay(entryA, counterpart),
+          countA: entryA.count,
+          countB: counterpart.count,
+          sortKey: entryA.key
+        });
+      } else {
+        onlyInA.push({ value: formatValueForDisplay(entryA.display), count: entryA.count, sortKey: entryA.key });
+      }
+
+      if (entryA.count > 1) {
+        duplicatesA.push({ value: formatValueForDisplay(entryA.display), count: entryA.count, sortKey: entryA.key });
+      }
+    });
+
+    valuesB.map.forEach(entryB => {
+      if (!valuesA.map.has(entryB.key)) {
+        onlyInB.push({ value: formatValueForDisplay(entryB.display), count: entryB.count, sortKey: entryB.key });
+      }
+
+      if (entryB.count > 1) {
+        duplicatesB.push({ value: formatValueForDisplay(entryB.display), count: entryB.count, sortKey: entryB.key });
+      }
+    });
+
+    const sortAlpha = (a, b) => a.sortKey.localeCompare(b.sortKey, undefined, { sensitivity: 'base', numeric: true });
+    const sortByCount = (a, b) => b.count - a.count || sortAlpha(a, b);
+
+    matches.sort(sortAlpha);
+    onlyInA.sort(sortAlpha);
+    onlyInB.sort(sortAlpha);
+    duplicatesA.sort(sortByCount);
+    duplicatesB.sort(sortByCount);
+
+    return {
+      matches,
+      onlyInA,
+      onlyInB,
+      duplicatesA,
+      duplicatesB,
+      totals: {
+        rowsA: datasetA.rows.length,
+        rowsB: datasetB.rows.length,
+        valuesComparedA: valuesA.valueCount,
+        valuesComparedB: valuesB.valueCount,
+        uniqueA: valuesA.map.size,
+        uniqueB: valuesB.map.size,
+        matches: matches.length,
+        onlyA: onlyInA.length,
+        onlyB: onlyInB.length,
+        duplicatesA: duplicatesA.length,
+        duplicatesB: duplicatesB.length
+      }
+    };
+  }
+
+  function escapeHtml(text) {
+    const value = text === null || text === undefined ? '' : String(text);
+    return value
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  function renderTableRows(tbody, emptyState, rows, renderRow) {
+    if (!tbody || !emptyState) {
+      return;
+    }
+
+    if (!rows.length) {
+      tbody.innerHTML = '';
+      emptyState.style.display = 'block';
+      return;
+    }
+
+    const fragments = rows.map(renderRow).join('');
+    tbody.innerHTML = fragments;
+    emptyState.style.display = 'none';
+  }
+
+  function renderResults(results, datasetA, datasetB, columnA, columnB) {
+    if (elements.introState) {
+      elements.introState.style.display = 'none';
+    }
+
+    elements.overviewSection.hidden = false;
+    elements.matchesSection.hidden = false;
+    elements.onlyASection.hidden = false;
+    elements.onlyBSection.hidden = false;
+    elements.duplicatesSection.hidden = false;
+
+    const overviewParts = [];
+    overviewParts.push(`Comparing ${formatNumber(results.totals.valuesComparedA)} values from ${datasetA.fileName}`);
+    overviewParts.push(`against ${formatNumber(results.totals.valuesComparedB)} values from ${datasetB.fileName}.`);
+    elements.overviewDescription.textContent = overviewParts.join(' ');
+
+    if (elements.selectedColumns) {
+      elements.selectedColumns.innerHTML = `<span>A: ${escapeHtml(columnA)}</span><span>B: ${escapeHtml(columnB)}</span>`;
+    }
+
+    if (elements.summaryGrid) {
+      const metrics = [
+        {
+          title: 'Rows Analyzed · Dataset A',
+          value: formatNumber(results.totals.rowsA),
+          subtext: datasetA.fileName
+        },
+        {
+          title: 'Rows Analyzed · Dataset B',
+          value: formatNumber(results.totals.rowsB),
+          subtext: datasetB.fileName
+        },
+        {
+          title: 'Unique Values · Dataset A',
+          value: formatNumber(results.totals.uniqueA),
+          subtext: `${formatNumber(results.totals.valuesComparedA)} values considered`
+        },
+        {
+          title: 'Unique Values · Dataset B',
+          value: formatNumber(results.totals.uniqueB),
+          subtext: `${formatNumber(results.totals.valuesComparedB)} values considered`
+        },
+        {
+          title: 'Values in Both Files',
+          value: formatNumber(results.totals.matches),
+          subtext: 'Shared across the selected columns'
+        },
+        {
+          title: 'Only in Dataset A',
+          value: formatNumber(results.totals.onlyA),
+          subtext: 'Missing from Dataset B'
+        },
+        {
+          title: 'Only in Dataset B',
+          value: formatNumber(results.totals.onlyB),
+          subtext: 'Missing from Dataset A'
+        }
+      ];
+
+      elements.summaryGrid.innerHTML = metrics
+        .map(metric => {
+          return `
+            <article class="summary-card">
+              <h4>${escapeHtml(metric.title)}</h4>
+              <div class="metric-value">${escapeHtml(metric.value)}</div>
+              <div class="metric-subtext">${escapeHtml(metric.subtext)}</div>
+            </article>
+          `;
+        })
+        .join('');
+    }
+
+    renderTableRows(
+      elements.matchesTableBody,
+      elements.tableEmptyStates.matches,
+      results.matches,
+      row => `
+        <tr>
+          <td>${escapeHtml(formatValueForDisplay(row.value))}</td>
+          <td>${escapeHtml(formatNumber(row.countA))}</td>
+          <td>${escapeHtml(formatNumber(row.countB))}</td>
+        </tr>
+      `
+    );
+
+    renderTableRows(
+      elements.onlyATableBody,
+      elements.tableEmptyStates.onlyA,
+      results.onlyInA,
+      row => `
+        <tr>
+          <td>${escapeHtml(formatValueForDisplay(row.value))}</td>
+          <td>${escapeHtml(formatNumber(row.count))}</td>
+        </tr>
+      `
+    );
+
+    renderTableRows(
+      elements.onlyBTableBody,
+      elements.tableEmptyStates.onlyB,
+      results.onlyInB,
+      row => `
+        <tr>
+          <td>${escapeHtml(formatValueForDisplay(row.value))}</td>
+          <td>${escapeHtml(formatNumber(row.count))}</td>
+        </tr>
+      `
+    );
+
+    renderTableRows(
+      elements.duplicatesATableBody,
+      elements.tableEmptyStates.duplicatesA,
+      results.duplicatesA,
+      row => `
+        <tr>
+          <td>${escapeHtml(formatValueForDisplay(row.value))}</td>
+          <td>${escapeHtml(formatNumber(row.count))}</td>
+        </tr>
+      `
+    );
+
+    renderTableRows(
+      elements.duplicatesBTableBody,
+      elements.tableEmptyStates.duplicatesB,
+      results.duplicatesB,
+      row => `
+        <tr>
+          <td>${escapeHtml(formatValueForDisplay(row.value))}</td>
+          <td>${escapeHtml(formatNumber(row.count))}</td>
+        </tr>
+      `
+    );
+  }
+
+  function formatNumber(value) {
+    return Number.isFinite(value) ? value.toLocaleString() : '0';
+  }
+
+  async function runComparison() {
+    if (!state.datasets.A || !state.datasets.B || !state.selections.A || !state.selections.B) {
+      setStatus(elements.comparisonStatus, 'Load both datasets and choose a column from each before running a comparison.', 'warning');
+      return;
+    }
+
+    const options = getOptions();
+    setStatus(elements.comparisonStatus, 'Comparing selected columns…', 'info');
+
+    try {
+      const results = computeComparison(state.datasets.A, state.datasets.B, state.selections.A, state.selections.B, options);
+      state.results = results;
+      renderResults(results, state.datasets.A, state.datasets.B, state.selections.A, state.selections.B);
+      setStatus(elements.comparisonStatus, 'Comparison complete. Scroll down to review the results.', 'success');
+      AppUI.setSectionCollapsed('selectionSection', true);
+    } catch (error) {
+      console.error('Comparison failed', error);
+      setStatus(elements.comparisonStatus, `Comparison failed: ${error.message || 'Unknown error'}`, 'error');
+    }
+  }
+
+  function parseFile(file) {
+    const extension = (file.name.split('.').pop() || '').toLowerCase();
+
+    if (extension === 'csv') {
+      return parseCsv(file);
+    }
+
+    if (extension === 'xlsx' || extension === 'xls') {
+      return parseWorkbook(file);
+    }
+
+    return Promise.reject(new Error('Unsupported file type. Please upload a CSV or Excel file.'));
+  }
+
+  function parseCsv(file) {
+    const headerCounts = {};
+
+    return new Promise((resolve, reject) => {
+      Papa.parse(file, {
+        header: true,
+        skipEmptyLines: 'greedy',
+        transformHeader: (header, index) => {
+          const base = (header || '').trim() || `Column ${index + 1}`;
+          const count = headerCounts[base] || 0;
+          headerCounts[base] = count + 1;
+          return count === 0 ? base : `${base} (${count + 1})`;
+        },
+        complete: results => {
+          if (results.errors && results.errors.length) {
+            reject(new Error(results.errors[0].message));
+            return;
+          }
+
+          const columns = ensureUniqueColumnNames(results.meta?.fields || []);
+          const rows = (results.data || []).filter(row => !isRowEmpty(row));
+          resolve({ rows, columns });
+        },
+        error: error => {
+          reject(error);
+        }
+      });
+    });
+  }
+
+  function parseWorkbook(file) {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onerror = () => reject(new Error('Unable to read file.'));
+      reader.onload = event => {
+        try {
+          const data = new Uint8Array(event.target.result);
+          const workbook = XLSX.read(data, { type: 'array' });
+          const [firstSheet] = workbook.SheetNames;
+          if (!firstSheet) {
+            resolve({ rows: [], columns: [] });
+            return;
+          }
+
+          const worksheet = workbook.Sheets[firstSheet];
+          const rowsArray = XLSX.utils.sheet_to_json(worksheet, { header: 1, defval: '' });
+          if (!rowsArray.length) {
+            resolve({ rows: [], columns: [] });
+            return;
+          }
+
+          const [headerRow, ...dataRows] = rowsArray;
+          const columns = ensureUniqueColumnNames(headerRow);
+
+          const rows = dataRows
+            .map(cells => {
+              const row = {};
+              columns.forEach((columnName, index) => {
+                row[columnName] = cells[index] ?? '';
+              });
+              return row;
+            })
+            .filter(row => !isRowEmpty(row));
+
+          resolve({ rows, columns });
+        } catch (error) {
+          reject(error);
+        }
+      };
+      reader.readAsArrayBuffer(file);
+    });
+  }
+
+  function isRowEmpty(row) {
+    return Object.values(row).every(value => {
+      if (value === null || value === undefined) {
+        return true;
+      }
+      if (typeof value === 'string') {
+        return value.trim().length === 0;
+      }
+      return String(value).trim().length === 0;
+    });
+  }
+
+  function ensureUniqueColumnNames(columns) {
+    const seen = new Map();
+    return columns.map((rawName, index) => {
+      const base = (rawName && String(rawName).trim()) || `Column ${index + 1}`;
+      const count = seen.get(base) || 0;
+      seen.set(base, count + 1);
+      if (count === 0) {
+        return base;
+      }
+      return `${base} (${count + 1})`;
+    });
+  }
+
+  return {
+    initialize() {
+      cacheElements();
+      attachEventListeners();
+      if (elements.columnSelects.A) {
+        resetColumnSelect(elements.columnSelects.A, 'A');
+      }
+      if (elements.columnSelects.B) {
+        resetColumnSelect(elements.columnSelects.B, 'B');
+      }
+      GraphTokenManager.subscribe(updateTokenStatus);
+    }
+  };
+})();

--- a/column-compare/index.html
+++ b/column-compare/index.html
@@ -1,0 +1,306 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Column Comparison Tool</title>
+  <link rel="stylesheet" href="../shared/styles.css">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <div class="app-container">
+    <header class="header">
+      <h1>Column Comparison Tool</h1>
+      <div class="header-actions">
+        <a class="btn btn-secondary" href="../index.html">🏠 Home</a>
+        <button class="btn btn-secondary" onclick="AppUI.toggleDarkMode()">🌙 Dark Mode</button>
+      </div>
+    </header>
+
+    <div class="main-content">
+      <aside class="setup-panel" id="setupPanel">
+        <div class="collapsible-section">
+          <div class="collapsible-header" onclick="AppUI.toggleSection('tokenSection')">
+            <span class="collapse-icon" id="tokenSectionIcon">▼</span>
+            <h3 style="margin: 0;">Microsoft Graph Token</h3>
+          </div>
+
+          <div class="collapsible-content" id="tokenSection">
+            <div class="wizard-step">
+              <h3>
+                <span class="step-number">1</span>
+                Optional: Store Your Graph Token
+              </h3>
+              <p class="helper-text">
+                Paste a Microsoft Graph Explorer access token to reuse it across every tool. This comparison utility does not
+                call Graph, but the shared token storage keeps your workspace in sync.
+              </p>
+              <div class="form-group">
+                <label for="graphToken">Access Token:</label>
+                <input type="password" id="graphToken" placeholder="Paste your Microsoft Graph access token here...">
+                <small class="form-hint" id="tokenStatus">No token stored yet.</small>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="collapsible-section">
+          <div class="collapsible-header" onclick="AppUI.toggleSection('loadSection')">
+            <span class="collapse-icon" id="loadSectionIcon">▼</span>
+            <h3 style="margin: 0;">Load Datasets</h3>
+          </div>
+
+          <div class="collapsible-content" id="loadSection">
+            <div class="wizard-step">
+              <h3>
+                <span class="step-number">2</span>
+                Upload CSV or Excel Files
+              </h3>
+              <p class="helper-text">Choose one file for each dataset. The first row should contain column headers.</p>
+
+              <div class="dataset-upload" data-dataset="A">
+                <h4>Dataset A</h4>
+                <div class="file-upload">
+                  <input type="file" id="datasetAFile" accept=".csv,.xlsx,.xls">
+                  <label class="file-upload-label" for="datasetAFile">
+                    📁 Upload Dataset A<br>
+                    <small>Accepts CSV, XLSX, or XLS.</small>
+                  </label>
+                </div>
+                <div class="dataset-summary" id="datasetASummary">No file selected yet.</div>
+                <div class="status-message" id="datasetAStatus" role="status" aria-live="polite"></div>
+              </div>
+
+              <div class="dataset-upload" data-dataset="B">
+                <h4>Dataset B</h4>
+                <div class="file-upload">
+                  <input type="file" id="datasetBFile" accept=".csv,.xlsx,.xls">
+                  <label class="file-upload-label" for="datasetBFile">
+                    📁 Upload Dataset B<br>
+                    <small>Accepts CSV, XLSX, or XLS.</small>
+                  </label>
+                </div>
+                <div class="dataset-summary" id="datasetBSummary">No file selected yet.</div>
+                <div class="status-message" id="datasetBStatus" role="status" aria-live="polite"></div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="collapsible-section">
+          <div class="collapsible-header" onclick="AppUI.toggleSection('selectionSection')">
+            <span class="collapse-icon" id="selectionSectionIcon">▼</span>
+            <h3 style="margin: 0;">Select Columns &amp; Options</h3>
+          </div>
+
+          <div class="collapsible-content" id="selectionSection">
+            <div class="wizard-step">
+              <h3>
+                <span class="step-number">3</span>
+                Choose Columns to Compare
+              </h3>
+              <p class="helper-text">Columns populate after each dataset loads. Only non-empty values are considered when the blank filter is enabled.</p>
+
+              <div class="form-group">
+                <label for="columnSelectA">Column from Dataset A</label>
+                <select id="columnSelectA" disabled>
+                  <option value="">Load Dataset A to choose a column</option>
+                </select>
+              </div>
+
+              <div class="form-group">
+                <label for="columnSelectB">Column from Dataset B</label>
+                <select id="columnSelectB" disabled>
+                  <option value="">Load Dataset B to choose a column</option>
+                </select>
+              </div>
+
+              <div class="form-group toggle-row">
+                <label class="switch">
+                  <input type="checkbox" id="ignoreCaseToggle" checked>
+                  <span class="slider"></span>
+                </label>
+                <div>
+                  <div class="form-label">Ignore Letter Case</div>
+                  <small class="form-hint">Treat values such as "Alice" and "alice" as matches.</small>
+                </div>
+              </div>
+
+              <div class="form-group toggle-row">
+                <label class="switch">
+                  <input type="checkbox" id="trimToggle" checked>
+                  <span class="slider"></span>
+                </label>
+                <div>
+                  <div class="form-label">Trim Whitespace</div>
+                  <small class="form-hint">Remove leading/trailing spaces before comparing values.</small>
+                </div>
+              </div>
+
+              <div class="form-group toggle-row">
+                <label class="switch">
+                  <input type="checkbox" id="skipBlankToggle" checked>
+                  <span class="slider"></span>
+                </label>
+                <div>
+                  <div class="form-label">Skip Blank Values</div>
+                  <small class="form-hint">Ignore rows where the chosen column is empty.</small>
+                </div>
+              </div>
+
+              <button class="btn btn-primary" id="compareButton" disabled>Run Comparison</button>
+              <div class="status-message" id="comparisonStatus" role="status" aria-live="polite"></div>
+            </div>
+          </div>
+        </div>
+      </aside>
+
+      <main class="viz-container">
+        <section class="intro-state" id="introState">
+          <h2>Compare Unique Values Between Files</h2>
+          <p>
+            Upload two spreadsheets, choose the columns to inspect, and instantly see which values exist in both tables or are
+            missing from one. Use the toggles to control case sensitivity, whitespace handling, and whether blank cells should
+            be ignored.
+          </p>
+          <ul>
+            <li>The overview cards summarize the number of unique values and overlaps.</li>
+            <li>Tables below break down matches, items only in Dataset A, items only in Dataset B, and duplicates within each file.</li>
+            <li>Download-ready exports will be added in future iterations if needed.</li>
+          </ul>
+        </section>
+
+        <section class="comparison-overview" id="overviewSection" hidden>
+          <div class="section-header">
+            <div>
+              <h2>Comparison Overview</h2>
+              <p id="overviewDescription" class="section-description"></p>
+            </div>
+            <div class="column-pill" id="selectedColumns"></div>
+          </div>
+          <div class="summary-grid" id="summaryGrid"></div>
+        </section>
+
+        <section class="results-section" id="matchesSection" hidden>
+          <div class="section-header">
+            <div>
+              <h3>Values Present in Both Files</h3>
+              <p class="section-description">Matched values show how frequently they appear in each dataset.</p>
+            </div>
+          </div>
+          <div class="table-wrapper">
+            <table class="results-table">
+              <thead>
+                <tr>
+                  <th scope="col">Value</th>
+                  <th scope="col">Occurrences in A</th>
+                  <th scope="col">Occurrences in B</th>
+                </tr>
+              </thead>
+              <tbody id="matchesTableBody"></tbody>
+            </table>
+            <div class="table-empty" id="matchesEmpty">No overlapping values detected.</div>
+          </div>
+        </section>
+
+        <section class="results-section" id="onlyASection" hidden>
+          <div class="section-header">
+            <div>
+              <h3>Only in Dataset A</h3>
+              <p class="section-description">Values that do not appear in the selected column from Dataset B.</p>
+            </div>
+          </div>
+          <div class="table-wrapper">
+            <table class="results-table">
+              <thead>
+                <tr>
+                  <th scope="col">Value</th>
+                  <th scope="col">Occurrences</th>
+                </tr>
+              </thead>
+              <tbody id="onlyATableBody"></tbody>
+            </table>
+            <div class="table-empty" id="onlyAEmpty">Every value from Dataset A was also present in Dataset B.</div>
+          </div>
+        </section>
+
+        <section class="results-section" id="onlyBSection" hidden>
+          <div class="section-header">
+            <div>
+              <h3>Only in Dataset B</h3>
+              <p class="section-description">Values that do not appear in the selected column from Dataset A.</p>
+            </div>
+          </div>
+          <div class="table-wrapper">
+            <table class="results-table">
+              <thead>
+                <tr>
+                  <th scope="col">Value</th>
+                  <th scope="col">Occurrences</th>
+                </tr>
+              </thead>
+              <tbody id="onlyBTableBody"></tbody>
+            </table>
+            <div class="table-empty" id="onlyBEmpty">Every value from Dataset B was also present in Dataset A.</div>
+          </div>
+        </section>
+
+        <section class="results-section" id="duplicatesSection" hidden>
+          <div class="section-header">
+            <div>
+              <h3>Duplicate Values Within Each Dataset</h3>
+              <p class="section-description">These values appear more than once in the selected column of a file.</p>
+            </div>
+          </div>
+          <div class="duplicate-grid">
+            <div>
+              <h4>Dataset A</h4>
+              <div class="table-wrapper">
+                <table class="results-table">
+                  <thead>
+                    <tr>
+                      <th scope="col">Value</th>
+                      <th scope="col">Occurrences</th>
+                    </tr>
+                  </thead>
+                  <tbody id="duplicatesATableBody"></tbody>
+                </table>
+                <div class="table-empty" id="duplicatesAEmpty">No duplicates found in Dataset A.</div>
+              </div>
+            </div>
+            <div>
+              <h4>Dataset B</h4>
+              <div class="table-wrapper">
+                <table class="results-table">
+                  <thead>
+                    <tr>
+                      <th scope="col">Value</th>
+                      <th scope="col">Occurrences</th>
+                    </tr>
+                  </thead>
+                  <tbody id="duplicatesBTableBody"></tbody>
+                </table>
+                <div class="table-empty" id="duplicatesBEmpty">No duplicates found in Dataset B.</div>
+              </div>
+            </div>
+          </div>
+        </section>
+      </main>
+    </div>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/papaparse@5.4.1/papaparse.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js"></script>
+  <script src="../shared/ui.js"></script>
+  <script src="../shared/graph-token.js"></script>
+  <script src="comparer.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      AppUI.initialize();
+      GraphTokenManager.initialize();
+      AppUI.setSectionCollapsed('tokenSection', true);
+      ColumnComparer.initialize();
+    });
+  </script>
+</body>
+</html>

--- a/column-compare/styles.css
+++ b/column-compare/styles.css
@@ -1,0 +1,163 @@
+.dataset-upload {
+  margin-bottom: 1.5rem;
+  padding: 1rem;
+  border: 1px dashed var(--border-subtle);
+  border-radius: 8px;
+  background: var(--surface-elevated);
+}
+
+.dataset-upload h4 {
+  margin: 0 0 0.75rem;
+  font-size: 1rem;
+}
+
+.dataset-summary {
+  margin-top: 0.75rem;
+  font-size: 0.9rem;
+  color: var(--text-subtle);
+}
+
+.status-message {
+  margin-top: 0.5rem;
+}
+
+.intro-state {
+  background: var(--surface-elevated);
+  border-radius: 12px;
+  padding: 2rem;
+  box-shadow: var(--shadow-sm);
+}
+
+.intro-state ul {
+  margin-top: 1rem;
+  padding-left: 1.25rem;
+}
+
+.section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.section-header h2,
+.section-header h3 {
+  margin: 0;
+}
+
+.section-description {
+  margin: 0.25rem 0 0;
+  color: var(--text-subtle);
+}
+
+.column-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 999px;
+  background: var(--accent-muted);
+  color: var(--accent-strong);
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.column-pill span {
+  display: inline-block;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  background: var(--surface);
+}
+
+.summary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+}
+
+.summary-card {
+  background: var(--surface-elevated);
+  border-radius: 10px;
+  padding: 1.25rem;
+  box-shadow: var(--shadow-xs);
+}
+
+.summary-card h4 {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--text-subtle);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.summary-card .metric-value {
+  margin-top: 0.5rem;
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: var(--text-strong);
+}
+
+.summary-card .metric-subtext {
+  margin-top: 0.25rem;
+  font-size: 0.85rem;
+  color: var(--text-subtle);
+}
+
+.results-section {
+  margin-top: 2.5rem;
+}
+
+.table-wrapper {
+  position: relative;
+  border-radius: 10px;
+  overflow: hidden;
+  box-shadow: var(--shadow-xs);
+}
+
+.results-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: var(--surface);
+}
+
+.results-table th,
+.results-table td {
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--border-subtle);
+  text-align: left;
+}
+
+.results-table th {
+  background: var(--surface-elevated);
+  font-weight: 600;
+  color: var(--text-subtle);
+}
+
+.results-table tbody tr:nth-child(odd) td {
+  background: var(--surface-alt);
+}
+
+.table-empty {
+  padding: 1rem;
+  text-align: center;
+  color: var(--text-subtle);
+  font-style: italic;
+}
+
+.duplicate-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
+}
+
+@media (max-width: 900px) {
+  .section-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .column-pill {
+    align-self: stretch;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -85,6 +85,28 @@
         </section>
 
         <section class="tool-card">
+          <h2>Column Comparison Tool</h2>
+          <p>Identify overlaps, missing values, and duplicates by comparing columns from two CSV or Excel files with flexible matching rules.</p>
+          <div class="meta meta-grid">
+            <div class="meta-item">
+              <div class="meta-heading">
+                <span aria-hidden="true">📂</span>
+                <span>Data</span>
+              </div>
+              <p>CSV/XLSX tables</p>
+            </div>
+            <div class="meta-item">
+              <div class="meta-heading">
+                <span aria-hidden="true">🛠️</span>
+                <span>Features</span>
+              </div>
+              <p>Column matching, duplicate detection, summaries</p>
+            </div>
+          </div>
+          <a class="btn btn-primary" href="column-compare/index.html">Open Comparator</a>
+        </section>
+
+        <section class="tool-card">
           <h2>Tool Starter Template</h2>
           <p>Kickstart new utilities with prebuilt token, input, and settings panels plus a ready-made visualization area.</p>
           <div class="meta meta-grid">


### PR DESCRIPTION
## Summary
- add a Column Comparison Tool UI with collapsible setup panels, upload inputs for two datasets, and detailed results tables for overlaps and gaps
- implement comparison logic to parse CSV/XLSX files, normalize values with configurable options, and summarize matches, missing values, and duplicates
- style the new experience and update the workspace landing page and README to link to the tool

## Testing
- not run (frontend-only changes)


------
https://chatgpt.com/codex/tasks/task_b_68ce85429c1883288ee00b36b1e83601