### PR TITLE
Align tool styling and update shared design guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,66 @@
 # My Tools Workspace
 
-This repository hosts a collection of Microsoft 365 helper utilities that share a unified look and feel. Use the guidelines below when extending the workspace with new tools so that every experience feels cohesive.
+This repository hosts a suite of Microsoft 365 helper utilities that intentionally share a unified layout, color system, and workflow. Use the guidance below when updating existing tools or introducing new experiences so that everything in the workspace feels cohesive.
 
 ## Available Tools & Templates
-- **Organization License Viewer** (`/org-license-viewer`): Visualize reporting lines, highlight ChatGPT license coverage, and explore organizational metrics with collapsible filter panels and chart controls.
-- **Profile Data Appender** (`/user-data-appender`): Upload CSV/Excel files, append Microsoft 365 profile attributes, and export enriched lists with built-in progress and status messaging.
-- **Column Comparison Tool** (`/column-compare`): Compare columns from two CSV/Excel files to highlight shared values, gaps, and duplicates with configurable matching rules.
-- **Tool Starter Template** (`/tool-template`): A base layout with Microsoft Graph token handling, collapsible input and settings panels, and a neutral main canvas ready for custom tables, charts, or outputs.
+- **Organization License Viewer** (`/org-license-viewer`): Visualize reporting lines, highlight ChatGPT license coverage, and explore team metrics with collapsible chart controls.
+- **Profile Data Appender** (`/user-data-appender`): Upload CSV/Excel files, append Microsoft 365 profile attributes, and export enriched lists with progress and status messaging.
+- **Column Comparison Tool** (`/column-compare`): Compare columns from two CSV/Excel files to surface overlaps, gaps, and duplicates with configurable matching rules.
+- **Tool Starter Template** (`/tool-template`): A baseline layout with Microsoft Graph token handling, collapsible input/settings panels, and a neutral main canvas ready for custom visualizations.
 
-## Landing Page Layout
-- Cards should be wide rectangles that highlight the tool name, a short description, and structured “Data” and “Features” callouts.
-- Use the existing `tool-card`, `meta-grid`, and `meta-item` classes from `shared/home.css` to keep the layout consistent.
-- Each card should include a primary button that links to the tool’s index page.
+## Shared Design System
+### Layout Shell
+- Every tool page loads `../shared/styles.css` and uses the shared header plus a two-column body (`.setup-panel` on the left, `.viz-container` on the right).
+- The header always shows the tool title, a **Home** button linking back to `/index.html`, and the dark-mode toggle.
+- The left panel is fixed at 380px wide, scrolls independently, and should keep its structure lightweight so the main canvas remains the visual focus.
 
-## Tool Page Conventions
-- Every tool page lives in its own folder and loads the shared styles from `../shared/styles.css`.
-- The header must include a **Home** button linking back to `/index.html` as well as the dark-mode toggle button.
-- The left-hand panel should follow this order:
-  1. **Microsoft Graph Token** collapsible section (collapsed by default).
-  2. **Load Data** collapsible section (collapsed by default).
-  3. Any additional filters, controls, or output sections.
-- Use the shared `AppUI.setSectionCollapsed` helper to collapse sections on page load.
-- Whenever a workflow completes a major action (e.g., data fetch or upload), auto-collapse the load section so the user can focus on downstream controls.
+### Setup Panel Standards
+1. **Microsoft Graph Token** (collapsed on load)
+   - Include an input with `id="graphToken"` and a hint element with `id="tokenStatus"`.
+   - Call `GraphTokenManager.initialize({ onTokenChange: token => AppUI.updateTokenStatus('tokenStatus', token) });` inside your tool script so the status automatically reflects stored tokens.
+   - Collapse the section on page load with `AppUI.setSectionCollapsed('tokenSection', true);`.
+2. **Load Data / Inputs** (collapsed on load)
+   - Pair file pickers, textarea inputs, or API triggers with contextual helper text.
+   - After a successful load, call `AppUI.setSectionCollapsed('loadSection', true);` so users can focus on downstream controls.
+3. **Additional Controls**
+   - Organize filters, toggles, and advanced settings into logical sections. Use `.wizard-step` blocks for consistent spacing.
 
-## Shared Resources
-- Global styles live in `shared/styles.css`; landing-page-specific styles live in `shared/home.css`.
-- Token handling is centralized in `shared/graph-token.js`. Always reuse this module to persist and broadcast token updates between tools.
-- Any reusable UI helpers should be added to `shared/ui.js` to avoid duplication.
+### Content Area Patterns
+- The shared `.viz-container` provides a default 2rem gutter, scroll behavior, and neutral background. Override `padding` locally when a tool needs a full-bleed canvas (see the license viewer and data appender for examples).
+- Reuse existing utility classes: `.summary-grid`, `.results-table`, `.status-message`, and `.button-row` already handle spacing and responsive behavior.
+- Keep headline hierarchy consistent (`h2` for primary sections, `h3` inside panels) and prefer semantic tables or lists over ad-hoc div grids.
 
-## Development Tips
-- Keep new tool directories self-contained with their own `index.html`, supporting scripts, and styles.
-- Favor semantic HTML and accessible patterns (e.g., labelled inputs, descriptive button text).
-- Test new tools with both light and dark mode enabled to ensure adequate contrast.
+### Color & Spacing Tokens
+`shared/styles.css` exposes a small set of design tokens—reuse them rather than inventing new hex values:
+- Surfaces: `--surface`, `--surface-elevated`, `--surface-alt`.
+- Text: `--text-strong` (body copy) and `--text-subtle` (supporting text).
+- Borders & Shadows: `--border`, `--border-subtle`, `--shadow`, `--shadow-sm`, `--shadow-xs`.
+- Accents: `--primary`, `--primary-dark`, `--accent-muted`, `--accent-strong`, plus `--success`, `--warning`, and `--danger` for statuses.
 
-Following these conventions will ensure new utilities feel native to the workspace and can inherit improvements made to the shared components.
+Light and dark themes automatically remap those variables, so leaning on the shared tokens keeps every tool visually aligned and accessible.
+
+## Microsoft Graph Token Workflow
+- Always bootstrap token handling inside your tool script (not from inline HTML) using `GraphTokenManager.initialize`.
+- Update all dependent controls inside the `onTokenChange` callback. Most tools should:
+  - Call `AppUI.updateTokenStatus` to refresh the hint under the token input.
+  - Store the trimmed token in module state for validation and API calls.
+  - Trigger any derived UI (e.g., detected tenant domain, enabled/disabled buttons).
+- When a major workflow finishes (data fetched, comparison completed, etc.), collapse earlier setup sections via `AppUI.setSectionCollapsed` to guide the user forward.
+
+## Landing Page Standards
+- Tool cards live on `/index.html` and use the shared `tool-card`, `meta-grid`, and `meta-item` classes from `shared/home.css`.
+- Each card lists the tool name, a concise description, “Data” and “Features” callouts, and a primary button that opens the tool.
+- The landing page token card is the single place to seed the shared Microsoft Graph token—new tools should rely on that same storage.
+
+## Template as a Starting Point
+The `/tool-template` folder demonstrates the preferred wiring:
+- Collapsible token, input, and settings panels that already call `GraphTokenManager.initialize` and `AppUI.updateTokenStatus`.
+- Sample controls, toggle rows, and status messaging patterns ready to swap for real logic.
+- A neutral `.template-state` section that makes it easy to drop in charts, tables, or cards.
+Start new tools by copying this folder and replacing the placeholder logic while keeping the structure intact.
+
+## Development Practices
+- Keep each tool self-contained (HTML, JS, CSS). Shared utilities belong in `shared/` so improvements cascade everywhere.
+- Favor semantic HTML, labelled controls, and aria-friendly status regions (`role="status"`, `aria-live="polite"`).
+- Test light and dark modes, plus edge cases like empty data sets, to verify contrast and layout resilience.
+- Update this README whenever a new tool ships or shared conventions evolve so future work stays aligned.

--- a/column-compare/comparer.js
+++ b/column-compare/comparer.js
@@ -93,20 +93,12 @@ const ColumnComparer = (() => {
     elements.compareButton?.addEventListener('click', () => runComparison());
   }
 
-  function updateTokenStatus(token) {
+  function handleTokenChange(token) {
     if (!elements.tokenStatus) {
       return;
     }
 
-    if (!token) {
-      elements.tokenStatus.textContent = 'No token stored yet.';
-      return;
-    }
-
-    const start = token.slice(0, 12);
-    const end = token.slice(-6);
-    const preview = token.length > 18 ? `${start}…${end}` : token;
-    elements.tokenStatus.textContent = `Token stored (${token.length} characters, preview: ${preview}).`;
+    AppUI.updateTokenStatus(elements.tokenStatus, token, { start: 12, end: 6 });
   }
 
   function invalidateResults(message) {
@@ -712,7 +704,7 @@ const ColumnComparer = (() => {
       if (elements.columnSelects.B) {
         resetColumnSelect(elements.columnSelects.B, 'B');
       }
-      GraphTokenManager.subscribe(updateTokenStatus);
+      GraphTokenManager.initialize({ onTokenChange: handleTokenChange });
     }
   };
 })();

--- a/column-compare/index.html
+++ b/column-compare/index.html
@@ -297,7 +297,6 @@
   <script>
     document.addEventListener('DOMContentLoaded', () => {
       AppUI.initialize();
-      GraphTokenManager.initialize();
       AppUI.setSectionCollapsed('tokenSection', true);
       ColumnComparer.initialize();
     });

--- a/org-license-viewer/index.html
+++ b/org-license-viewer/index.html
@@ -48,6 +48,7 @@
               <div class="form-group">
                 <label for="graphToken">Access Token:</label>
                 <input type="password" id="graphToken" placeholder="Paste your Microsoft Graph access token here...">
+                <small class="form-hint" id="tokenStatus">No token stored yet.</small>
               </div>
             </div>
           </div>
@@ -324,7 +325,6 @@
   <script>
     document.addEventListener('DOMContentLoaded', () => {
       AppUI.initialize();
-      GraphTokenManager.initialize();
       AppUI.setSectionCollapsed('tokenSection', true);
       GraphAPI.initialize();
       OrgChart.initialize();

--- a/org-license-viewer/styles.css
+++ b/org-license-viewer/styles.css
@@ -6,6 +6,7 @@
   background: var(--bg);
   position: relative;
   overflow: hidden;
+  padding: 0;
 }
 
 #treeContainer {

--- a/shared/styles.css
+++ b/shared/styles.css
@@ -17,6 +17,16 @@
   --transition: all 0.3s ease;
   --node-stroke: #3498db;
   --link-color: #ccc;
+  --surface: var(--bg);
+  --surface-alt: #eef2f7;
+  --surface-elevated: #ffffff;
+  --text-strong: var(--text);
+  --text-subtle: var(--text-light);
+  --accent-muted: rgba(0, 102, 204, 0.12);
+  --accent-strong: var(--primary);
+  --border-subtle: rgba(44, 62, 80, 0.15);
+  --shadow-sm: 0 6px 12px rgba(15, 23, 42, 0.1);
+  --shadow-xs: 0 2px 4px rgba(15, 23, 42, 0.08);
 }
 
 .dark-mode {
@@ -33,6 +43,16 @@
   --border: #404040;
   --node-stroke: #69c0ff;
   --link-color: #555;
+  --surface: var(--bg-secondary);
+  --surface-alt: #242424;
+  --surface-elevated: #2f2f2f;
+  --text-strong: var(--text);
+  --text-subtle: var(--text-light);
+  --accent-muted: rgba(77, 166, 255, 0.18);
+  --accent-strong: var(--primary);
+  --border-subtle: rgba(255, 255, 255, 0.12);
+  --shadow-sm: 0 6px 12px rgba(0, 0, 0, 0.4);
+  --shadow-xs: 0 2px 4px rgba(0, 0, 0, 0.3);
 }
 
 *, *::before, *::after {
@@ -83,6 +103,14 @@ body {
   flex: 1;
   min-height: 0;
   overflow: hidden;
+}
+
+.viz-container {
+  flex: 1;
+  min-height: 0;
+  padding: 2rem;
+  background: var(--bg);
+  overflow-y: auto;
 }
 
 /* Setup Panel */

--- a/shared/ui.js
+++ b/shared/ui.js
@@ -52,6 +52,34 @@ const AppUI = (() => {
     }
   }
 
+  function resolveElement(target) {
+    if (!target) {
+      return null;
+    }
+
+    if (typeof target === 'string') {
+      return document.getElementById(target);
+    }
+
+    if (target instanceof HTMLElement) {
+      return target;
+    }
+
+    return null;
+  }
+
+  function formatTokenPreview(token, { start = 12, end = 6 } = {}) {
+    if (typeof token !== 'string' || !token.length) {
+      return '';
+    }
+
+    if (token.length <= start + end + 1) {
+      return token;
+    }
+
+    return `${token.slice(0, start)}…${token.slice(-end)}`;
+  }
+
   return {
     initialize(options = {}) {
       const { defaultTheme = 'light', rememberTheme = true } = options;
@@ -101,6 +129,28 @@ const AppUI = (() => {
         section.style.display = 'block';
         icon.textContent = '▼';
       }
+    },
+
+    updateTokenStatus(target, token, options = {}) {
+      const element = resolveElement(target);
+      if (!element) {
+        return;
+      }
+
+      const {
+        emptyMessage = 'No token stored yet.',
+        prefix = 'Token stored',
+        start = 12,
+        end = 6
+      } = options;
+
+      if (!token) {
+        element.textContent = emptyMessage;
+        return;
+      }
+
+      const preview = formatTokenPreview(token, { start, end });
+      element.textContent = `${prefix} (${token.length} characters, preview: ${preview}).`;
     }
   };
 })();

--- a/tool-template/template.js
+++ b/tool-template/template.js
@@ -1,17 +1,6 @@
 const TemplateApp = (() => {
-  function updateTokenStatus(token) {
-    const status = document.getElementById('tokenStatus');
-    if (!status) {
-      return;
-    }
-
-    if (!token) {
-      status.textContent = 'No token stored yet.';
-      return;
-    }
-
-    const preview = `${token.slice(0, 12)}…${token.slice(-6)}`;
-    status.textContent = `Token stored (${token.length} characters, preview: ${preview}).`;
+  function handleTokenChange(token) {
+    AppUI.updateTokenStatus('tokenStatus', token, { start: 12, end: 6 });
   }
 
   function formatSettingsSummary() {
@@ -101,7 +90,7 @@ const TemplateApp = (() => {
 
   function initialize() {
     AppUI.initialize();
-    GraphTokenManager.initialize({ onTokenChange: updateTokenStatus });
+    GraphTokenManager.initialize({ onTokenChange: handleTokenChange });
     collapseDefaults();
     bindEvents();
 

--- a/user-data-appender/graph-api.js
+++ b/user-data-appender/graph-api.js
@@ -72,6 +72,14 @@ const GraphAPI = (function() {
     }
   }
 
+  function handleTokenChange(token) {
+    accessToken = (token || '').trim();
+    loginDomain = accessToken ? extractDomainFromToken(accessToken) : '';
+    AppUI.updateTokenStatus('tokenStatus', accessToken, { start: 12, end: 6 });
+    updateDetectedDomainHint();
+    updateFetchButtonState();
+  }
+
   function buildLookupContext(emailValue) {
     const rawEmail = typeof emailValue === 'string' ? emailValue : '';
     const normalizedEmail = rawEmail.trim();
@@ -228,6 +236,7 @@ const GraphAPI = (function() {
         updateStatus('fetchStatus', '');
         updateDownloadButtons();
         updateFetchButtonState();
+        AppUI.setSectionCollapsed('loadSection', true);
       })
       .catch(error => {
         console.error('Error loading file:', error);
@@ -265,6 +274,7 @@ const GraphAPI = (function() {
     updateStatus('fetchStatus', '');
     updateDownloadButtons();
     updateFetchButtonState();
+    AppUI.setSectionCollapsed('loadSection', true);
   }
 
   function updateAppendModeUI() {
@@ -564,12 +574,7 @@ const GraphAPI = (function() {
   return {
     initialize: function() {
       if (typeof GraphTokenManager !== 'undefined') {
-        GraphTokenManager.subscribe(value => {
-          accessToken = value.trim();
-          loginDomain = accessToken ? extractDomainFromToken(accessToken) : '';
-          updateDetectedDomainHint();
-          updateFetchButtonState();
-        });
+        GraphTokenManager.initialize({ onTokenChange: handleTokenChange });
       }
 
       attachEventListeners();

--- a/user-data-appender/index.html
+++ b/user-data-appender/index.html
@@ -41,7 +41,8 @@
               <div class="form-group">
                 <label for="graphToken">Access Token:</label>
                 <input type="password" id="graphToken" placeholder="Paste your Microsoft Graph access token here...">
-                <span class="form-hint" id="detectedDomainHint">Detected sign-in domain: not detected yet.</span>
+                <small class="form-hint" id="tokenStatus">No token stored yet.</small>
+                <small class="form-hint" id="detectedDomainHint">Detected sign-in domain: not detected yet.</small>
               </div>
             </div>
           </div>
@@ -159,7 +160,6 @@
   <script>
     document.addEventListener('DOMContentLoaded', () => {
       AppUI.initialize();
-      GraphTokenManager.initialize();
       AppUI.setSectionCollapsed('tokenSection', true);
       DataTable.initialize();
       GraphAPI.initialize();

--- a/user-data-appender/styles.css
+++ b/user-data-appender/styles.css
@@ -8,6 +8,7 @@
   flex-direction: column;
   min-height: 0;
   overflow: hidden;
+  padding: 0;
 }
 
 .table-container {


### PR DESCRIPTION
## Summary
- document the shared layout, design tokens, and token workflow expectations in the README
- add shared surface/typography tokens plus a base `.viz-container` layout and a reusable `AppUI.updateTokenStatus` helper
- standardize token sections across tools by wiring `GraphTokenManager.initialize` in code, updating status hints, and collapsing load sections after data ingestion

## Testing
- No automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_b_68cf309e3c388328af2a9777f564b719