### PR TITLE
Remove Graph token panel from column compare

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository hosts a suite of Microsoft 365 helper utilities that intentional
 ## Available Tools & Templates
 - **Organization License Viewer** (`/org-license-viewer`): Visualize reporting lines, highlight ChatGPT license coverage, and explore team metrics with collapsible chart controls.
 - **Profile Data Appender** (`/user-data-appender`): Upload CSV/Excel files, append Microsoft 365 profile attributes, and export enriched lists with progress and status messaging.
-- **Column Comparison Tool** (`/column-compare`): Compare columns from two CSV/Excel files to surface overlaps, gaps, and duplicates with configurable matching rules.
+- **Column Comparison Tool** (`/column-compare`): Compare columns from two CSV/Excel files to surface overlaps, gaps, and duplicates with configurable matching rules. This tool is fully offline and intentionally omits the Microsoft Graph token panel.
 - **Tool Starter Template** (`/tool-template`): A baseline layout with Microsoft Graph token handling, collapsible input/settings panels, and a neutral main canvas ready for custom visualizations.
 
 ## Shared Design System
@@ -15,10 +15,10 @@ This repository hosts a suite of Microsoft 365 helper utilities that intentional
 - The left panel is fixed at 380px wide, scrolls independently, and should keep its structure lightweight so the main canvas remains the visual focus.
 
 ### Setup Panel Standards
-1. **Microsoft Graph Token** (collapsed on load)
-   - Include an input with `id="graphToken"` and a hint element with `id="tokenStatus"`.
-   - Call `GraphTokenManager.initialize({ onTokenChange: token => AppUI.updateTokenStatus('tokenStatus', token) });` inside your tool script so the status automatically reflects stored tokens.
-   - Collapse the section on page load with `AppUI.setSectionCollapsed('tokenSection', true);`.
+1. **Microsoft Graph Token** (only include when the tool makes Graph requests)
+   - Tools that do not need Microsoft Graph should skip the token panel entirely to keep the setup area focused on required inputs.
+   - When a tool does rely on Graph, include an input with `id="graphToken"`, a hint element with `id="tokenStatus"`, and call `GraphTokenManager.initialize({ onTokenChange: token => AppUI.updateTokenStatus('tokenStatus', token) });` inside your tool script.
+   - Collapse the token section on page load with `AppUI.setSectionCollapsed('tokenSection', true);` so it stays out of the way after configuration.
 2. **Load Data / Inputs** (collapsed on load)
    - Pair file pickers, textarea inputs, or API triggers with contextual helper text.
    - After a successful load, call `AppUI.setSectionCollapsed('loadSection', true);` so users can focus on downstream controls.
@@ -40,8 +40,8 @@ This repository hosts a suite of Microsoft 365 helper utilities that intentional
 Light and dark themes automatically remap those variables, so leaning on the shared tokens keeps every tool visually aligned and accessible.
 
 ## Microsoft Graph Token Workflow
-- Always bootstrap token handling inside your tool script (not from inline HTML) using `GraphTokenManager.initialize`.
-- Update all dependent controls inside the `onTokenChange` callback. Most tools should:
+- For tools that call Microsoft Graph, bootstrap token handling inside your tool script (not from inline HTML) using `GraphTokenManager.initialize`.
+- Update all dependent controls inside the `onTokenChange` callback. Graph-enabled tools should:
   - Call `AppUI.updateTokenStatus` to refresh the hint under the token input.
   - Store the trimmed token in module state for validation and API calls.
   - Trigger any derived UI (e.g., detected tenant domain, enabled/disabled buttons).
@@ -51,10 +51,11 @@ Light and dark themes automatically remap those variables, so leaning on the sha
 - Tool cards live on `/index.html` and use the shared `tool-card`, `meta-grid`, and `meta-item` classes from `shared/home.css`.
 - Each card lists the tool name, a concise description, “Data” and “Features” callouts, and a primary button that opens the tool.
 - The landing page token card is the single place to seed the shared Microsoft Graph token—new tools should rely on that same storage.
+- If a new tool does not require Graph data, do not surface an extra token panel; the landing page storage is enough for other tools that need it.
 
 ## Template as a Starting Point
 The `/tool-template` folder demonstrates the preferred wiring:
-- Collapsible token, input, and settings panels that already call `GraphTokenManager.initialize` and `AppUI.updateTokenStatus`.
+- Collapsible token, input, and settings panels that already call `GraphTokenManager.initialize` and `AppUI.updateTokenStatus` when your feature needs Graph.
 - Sample controls, toggle rows, and status messaging patterns ready to swap for real logic.
 - A neutral `.template-state` section that makes it easy to drop in charts, tables, or cards.
 Start new tools by copying this folder and replacing the placeholder logic while keeping the structure intact.

--- a/column-compare/comparer.js
+++ b/column-compare/comparer.js
@@ -52,7 +52,6 @@ const ColumnComparer = (() => {
       duplicatesA: document.getElementById('duplicatesAEmpty'),
       duplicatesB: document.getElementById('duplicatesBEmpty')
     };
-    elements.tokenStatus = document.getElementById('tokenStatus');
   }
 
   function attachEventListeners() {
@@ -91,14 +90,6 @@ const ColumnComparer = (() => {
     });
 
     elements.compareButton?.addEventListener('click', () => runComparison());
-  }
-
-  function handleTokenChange(token) {
-    if (!elements.tokenStatus) {
-      return;
-    }
-
-    AppUI.updateTokenStatus(elements.tokenStatus, token, { start: 12, end: 6 });
   }
 
   function invalidateResults(message) {
@@ -704,7 +695,6 @@ const ColumnComparer = (() => {
       if (elements.columnSelects.B) {
         resetColumnSelect(elements.columnSelects.B, 'B');
       }
-      GraphTokenManager.initialize({ onTokenChange: handleTokenChange });
     }
   };
 })();

--- a/column-compare/index.html
+++ b/column-compare/index.html
@@ -20,31 +20,6 @@
     <div class="main-content">
       <aside class="setup-panel" id="setupPanel">
         <div class="collapsible-section">
-          <div class="collapsible-header" onclick="AppUI.toggleSection('tokenSection')">
-            <span class="collapse-icon" id="tokenSectionIcon">▼</span>
-            <h3 style="margin: 0;">Microsoft Graph Token</h3>
-          </div>
-
-          <div class="collapsible-content" id="tokenSection">
-            <div class="wizard-step">
-              <h3>
-                <span class="step-number">1</span>
-                Optional: Store Your Graph Token
-              </h3>
-              <p class="helper-text">
-                Paste a Microsoft Graph Explorer access token to reuse it across every tool. This comparison utility does not
-                call Graph, but the shared token storage keeps your workspace in sync.
-              </p>
-              <div class="form-group">
-                <label for="graphToken">Access Token:</label>
-                <input type="password" id="graphToken" placeholder="Paste your Microsoft Graph access token here...">
-                <small class="form-hint" id="tokenStatus">No token stored yet.</small>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div class="collapsible-section">
           <div class="collapsible-header" onclick="AppUI.toggleSection('loadSection')">
             <span class="collapse-icon" id="loadSectionIcon">▼</span>
             <h3 style="margin: 0;">Load Datasets</h3>
@@ -53,7 +28,7 @@
           <div class="collapsible-content" id="loadSection">
             <div class="wizard-step">
               <h3>
-                <span class="step-number">2</span>
+                <span class="step-number">1</span>
                 Upload CSV or Excel Files
               </h3>
               <p class="helper-text">Choose one file for each dataset. The first row should contain column headers.</p>
@@ -96,7 +71,7 @@
           <div class="collapsible-content" id="selectionSection">
             <div class="wizard-step">
               <h3>
-                <span class="step-number">3</span>
+                <span class="step-number">2</span>
                 Choose Columns to Compare
               </h3>
               <p class="helper-text">Columns populate after each dataset loads. Only non-empty values are considered when the blank filter is enabled.</p>
@@ -292,12 +267,10 @@
   <script src="https://cdn.jsdelivr.net/npm/papaparse@5.4.1/papaparse.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js"></script>
   <script src="../shared/ui.js"></script>
-  <script src="../shared/graph-token.js"></script>
   <script src="comparer.js"></script>
   <script>
     document.addEventListener('DOMContentLoaded', () => {
       AppUI.initialize();
-      AppUI.setSectionCollapsed('tokenSection', true);
       ColumnComparer.initialize();
     });
   </script>


### PR DESCRIPTION
## Summary
- remove the Microsoft Graph token panel from the Column Comparison tool and adjust the setup steps
- strip the comparer script of Graph token handling
- document that purely offline tools should omit the token panel in the workspace README

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_b_68cf3641d7148328a3ed24ae4abc80fc