### PR TITLE
Add email username comparison toggle and overview anchors

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository hosts a suite of Microsoft 365 helper utilities that intentional
 - **Organization License Viewer** (`/org-license-viewer`): Visualize reporting lines, highlight ChatGPT license coverage, and explore team metrics with collapsible chart controls.
 - **Profile Data Appender** (`/user-data-appender`): Upload CSV/Excel files, append Microsoft 365 profile attributes, and export enriched lists with progress and status messaging.
 - **User Email Lookup** (`/user-email-lookup`): Paste a list of display names and fetch primary email addresses from Microsoft Graph with duplicate trimming, throttling controls, and export-friendly results.
-- **Column Comparison Tool** (`/column-compare`): Compare columns from two CSV/Excel files to surface overlaps, gaps, and duplicates with configurable matching rules. Export filtered CSV or Excel files for shared values or rows unique to each source. This tool is fully offline and intentionally omits the Microsoft Graph token panel.
+- **Column Comparison Tool** (`/column-compare`): Compare columns from two CSV/Excel files to surface overlaps, gaps, and duplicates with configurable matching rules. Export filtered CSV or Excel files for shared values or rows unique to each source. Overview summary cards link directly to the detailed tables, and an email username-only option helps match accounts that use different domains. This tool is fully offline and intentionally omits the Microsoft Graph token panel.
 - **Tool Starter Template** (`/tool-template`): A baseline layout with Microsoft Graph token handling, collapsible input/settings panels, and a neutral main canvas ready for custom visualizations.
 
 ## Shared Design System

--- a/column-compare/index.html
+++ b/column-compare/index.html
@@ -123,6 +123,17 @@
                 </div>
               </div>
 
+              <div class="form-group toggle-row">
+                <label class="switch">
+                  <input type="checkbox" id="emailUsernameToggle">
+                  <span class="slider"></span>
+                </label>
+                <div>
+                  <div class="form-label">Match Email Usernames Only</div>
+                  <small class="form-hint">When checked, compare the portion before the @ symbol so different domains for the same user count as a match.</small>
+                </div>
+              </div>
+
               <button class="btn btn-primary" id="compareButton" disabled>Run Comparison</button>
               <div class="status-message" id="comparisonStatus" role="status" aria-live="polite"></div>
             </div>

--- a/column-compare/styles.css
+++ b/column-compare/styles.css
@@ -77,10 +77,29 @@
 }
 
 .summary-card {
+  display: block;
   background: var(--surface-elevated);
   border-radius: 10px;
   padding: 1.25rem;
   box-shadow: var(--shadow-xs);
+}
+
+.summary-card.summary-card--link {
+  color: inherit;
+  text-decoration: none;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.summary-card.summary-card--link:hover,
+.summary-card.summary-card--link:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-sm);
+}
+
+.summary-card.summary-card--link:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 3px;
 }
 
 .summary-card h4 {


### PR DESCRIPTION
## Summary
- add an email-username-only comparison toggle to the Column Comparison Tool and thread the option through normalization
- link the overview summary cards to the corresponding detail tables and polish their interactive styling
- document the new behaviors in the workspace README

## Testing
- Manual verification in the browser

------
https://chatgpt.com/codex/tasks/task_b_68dd1f7d883c8328b9941ea78de4afc9